### PR TITLE
Remove SSL

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,11 +8,11 @@ var express = require('express'),
 	JawboneStrategy = require('passport-oauth').OAuth2Strategy,
 	port = 5000,
 	jawboneAuth = {
-       clientID: 'YOURID',
-       clientSecret: 'YOURSECRET',
-       authorizationURL: 'https://jawbone.com/auth/oauth2/auth',
-       tokenURL: 'https://jawbone.com/auth/oauth2/token',
-       callbackURL: 'https://localhost:5000/sleepdata'
+		clientID: process.env.JAWBONE_ID,
+		clientSecret: process.env.JAWBONE_SECRET,
+	authorizationURL: 'https://jawbone.com/auth/oauth2/auth',
+	tokenURL: 'https://jawbone.com/auth/oauth2/token',
+	callbackURL: 'https://' + process.env.DOMAIN + '/sleepdata'
 	};
 
 	app.use(bodyParser.json());

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 var express = require('express'),
 	app = express(),
 	ejs = require('ejs'),
-	https = require('https'),
+	http = require('http'),
 	fs = require('fs'),
 	bodyParser = require('body-parser'),
 	passport = require('passport'),
@@ -13,10 +13,6 @@ var express = require('express'),
        authorizationURL: 'https://jawbone.com/auth/oauth2/auth',
        tokenURL: 'https://jawbone.com/auth/oauth2/token',
        callbackURL: 'https://localhost:5000/sleepdata'
-    },
-	sslOptions = {
-		key: fs.readFileSync('./etc/letsencrypt/live/sleepify.me/privatekey.pem'),
-		cert: fs.readFileSync('./etc/letsencrypt/live/sleepify.me/certificate.pem')
 	};
 
 	app.use(bodyParser.json());
@@ -90,6 +86,6 @@ passport.use('jawbone', new JawboneStrategy({
     });
 }));
 
-var secureServer = https.createServer(sslOptions, app).listen(port, function(){
+var secureServer = http.createServer(app).listen(port, function(){
   	console.log('UP server listening on ' + port);
 });


### PR DESCRIPTION
This has the node app run without SSL. The intent being that we will have SSL terminated nginx in front.

I have also made it configurable via environment variables, so it's easier to use with Docker:
- `JAWBONE_ID`
- `JAWBONE_SECRET`
- `DOMAIN` = Their custom domain which is pointed at Carina, and will be secured via SSL. This must match the oath ural in the Jawbone account.
